### PR TITLE
Add sqlite_temp_master support

### DIFF
--- a/Sqliteman/sqliteman/database.h
+++ b/Sqliteman/sqliteman/database.h
@@ -63,6 +63,13 @@ class Database
 				
 	public:
 		static DbAttach getDatabases();
+
+        /*! \brief Gets correct sqlite_master or sqlite_temp_master.
+        \param schema a name of the DB schema
+        \retval QString either schema.sqlite_master or sqlite_temp_master
+        */
+        static QString getMaster(const QString & schema);
+
 		/*! \brief Gather user objects from sqlite_master by type.
 		It skips the resrved names "sqlite_%". See getSysObjects().
 		\param type a "enum" 'table', 'view', index etc. If it's empty all objects are selected.


### PR DESCRIPTION
'Temp' database has 'sqlite_temp_master' instead of 'temp.sqlite_master'.

Executing basic query like: 'CREATE TEMP TABLE TbTest(test text)' throws lot
of exceptions like : "Error while the list of ..."
