### PR TITLE
Categorize sqliteman.desktop under Database and Development

### DIFF
--- a/Sqliteman/sqliteman.desktop
+++ b/Sqliteman/sqliteman.desktop
@@ -8,6 +8,7 @@ Exec=sqliteman %f
 Terminal=false
 StartupNotify=true
 MimeType=application/x-sqlite3;
+Categories=Database;Development;
 
 # Translations
 GenericName[cs]=Sqlite administrace


### PR DESCRIPTION
This will cause Sqliteman to be properly categorized on LXDE. Slackware and Ubuntu have been applying similar patches for ages, but more purist distributions like Arch have been left out. See http://standards.freedesktop.org/menu-spec/latest/apas02.html